### PR TITLE
Ignore quotes when converting special characters to HTML entities

### DIFF
--- a/src/Darsain/Console/Console.php
+++ b/src/Darsain/Console/Console.php
@@ -142,6 +142,7 @@ class Console
 			$binding = DB::connection()->getPdo()->quote($binding);
 
 			$sql = preg_replace('/\?/', $binding, $sql, 1);
+			$sql = htmlspecialchars($sql);
 		}
 
 		static::$profile['queries'][] = array(

--- a/src/Darsain/Console/Console.php
+++ b/src/Darsain/Console/Console.php
@@ -142,7 +142,6 @@ class Console
 			$binding = DB::connection()->getPdo()->quote($binding);
 
 			$sql = preg_replace('/\?/', $binding, $sql, 1);
-			$sql = htmlspecialchars($sql);
 		}
 
 		static::$profile['queries'][] = array(

--- a/src/Darsain/Console/Console.php
+++ b/src/Darsain/Console/Console.php
@@ -142,7 +142,7 @@ class Console
 			$binding = DB::connection()->getPdo()->quote($binding);
 
 			$sql = preg_replace('/\?/', $binding, $sql, 1);
-			$sql = htmlspecialchars($sql);
+			$sql = htmlspecialchars($sql, ENT_NOQUOTES);
 		}
 
 		static::$profile['queries'][] = array(


### PR DESCRIPTION
Otherwise when you execute this command:

``` php
Role::create( array('name' => 'admin') );
```

This unreadable SQL log appears:

``` sql
insert into &amp;quot;roles&amp;quot; (&amp;quot;name&amp;quot;, &amp;quot;updated_at&amp;quot;, &amp;quot;created_at&amp;quot;) values ('admin', '2013-09-09 13:27:43', '2013-09-09 13:27:43') returning &amp;quot;id&amp;quot;
```
