### PR TITLE
Fix call to undefined method 'Route::currentRouteName()' in Laravel 4.1

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -9,7 +9,7 @@ use Darsain\Console\Console;
 */
 
 App::error(function (Exception $e, $code) {
-	if (Route::currentRouteName() !== 'console_execute') {
+	if (!Route::currentRouteNamed('console_execute')) {
 		return;
 	}
 	@ob_end_clean();


### PR DESCRIPTION
In Laravel 4.1 (now stable and released), the currentRouteName method of the Route facade has been dropped. Instead, you can use the new currentRouteNamed method.

Of course, this replacement may throw errors for users on 4.0 but since updating to the new version is dead simple, I believe you can reasonably make this change to stay on the edge !
