### PR TITLE
Fix problem when exception is thrown

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -9,7 +9,7 @@ use Darsain\Console\Console;
 */
 
 App::error(function (Exception $e, $code) {
-	if (Route::currentRouteName() !== 'console_execute') {
+	if (App::runningInConsole() || Request::url() !== 'console') {
 		return;
 	}
 	@ob_end_clean();


### PR DESCRIPTION
Currently, when an exception is thrown in the apllication, the current callback does not behave correctly. The issue comes from the Route::currentRouteName call. Changing the if condition fix the problem for me.
